### PR TITLE
Fixed navigation not following users location when not using simulator.

### DIFF
--- a/src/components/MapViewNavigation/index.js
+++ b/src/components/MapViewNavigation/index.js
@@ -128,13 +128,20 @@ export default class MapViewNavigation extends Component {
      */
     componentDidMount()
     {
-        this.watchId = navigator.geolocation.watchPosition(position => {
+        if (!this.props.simulate) {
+            this.watchId = geolocation.watchPosition(position => {
+                this.setPosition(position.coords);
+            },
+            (err) => {console.error(err)},
+            { enableHighAccuracy: true, timeout: 10, maximumAge: 0, distanceFilter: 0 });  
 
-            this.setPosition(position.coords);
-
-        });
+        } else {
+            this.watchId = navigator.geolocation.watchPosition(position => {
+                this.setPosition(position.coords);
+            });
+        }
     }
-
+    
     /**
      * @componentWillUnmount
      */


### PR DESCRIPTION
Altered the geoloaction.watchPosition improving its accuracy/ how often it polls the users location. I did not change it for the simulator as that worked extremely well. I added parameters for the "geolocation.watchPosition" function so that it polls users location every 10ms. I though it required this level of accuracy as it involves driving.

Fixes issue #16. 